### PR TITLE
Tambah shell script filter

### DIFF
--- a/content/git_init_--_memulakan_projek_baru.md
+++ b/content/git_init_--_memulakan_projek_baru.md
@@ -10,7 +10,7 @@ Dalam buku ini, kita akan membina sebuah projek contoh. Di sini kita akan membin
 
     ```sh
     $ mkdir PROJEK-GIT
-    $ cd PROJEK-GIT     # Masuk ke dalam folder tersebut
+    $ cd PROJEK-GIT
     ```
 
 2. Mulakan projek Git baru di dalam folder tersebut dengan `git init`:

--- a/css/base.css
+++ b/css/base.css
@@ -4,6 +4,24 @@ body {
     font-size: 15px;
 }
 
+.content code {
+    font-size: 10pt;
+}
+
+.content code .code-output {
+    color: #999999;
+}
+
+.content code .code-dollar {
+    display: inline-block;
+    margin-right: 10px;
+    color: #009900;
+    -moz-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -o-user-select: none;
+}
+
 .sidebar ul {
     list-style-type: none;
     margin: 0;

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
                 </ul>
             </nav>
 
-            <div v-if="content != null">{{{ content | marked }}}</div>
+            <div v-if="content != null">{{{ content | marked | shellScript }}}</div>
             <div v-else class="jumbotron">
                 <h1>Error 404</h1>
                 <p>Page Not Found</p>
@@ -58,6 +58,7 @@
 
     <!-- script src="lib/markdown.js"></script -->
     <script src="js/jquery.min.js"></script>
+    <script src="js/shell.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/vue/1.0.11/vue.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/marked/0.3.2/marked.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.1/lodash.min.js"></script>
@@ -110,7 +111,8 @@
     var vue = new Vue({
         el: 'body',
         filters: {
-            marked: marked
+            marked: marked,
+            shellScript: shellScript
         },
         data: {
             glossary: glossary,

--- a/js/shell.js
+++ b/js/shell.js
@@ -1,0 +1,30 @@
+function shellScript(content)
+{
+    var c = $('<div />', { html: content })
+
+    c.find('code.lang-sh').each(function () {
+        var lines = $(this).html()
+            .split('\n')
+            .filter(function (val) {
+                return val.length > 0;
+            }).map(function (val) {
+                return val.trim();
+            }).map(function (val) {
+                var cls = 'code-output';
+
+                // If line starts with $, it is a command. Otherwise, it is an output.
+                if (val[0] == '$') {
+                    cls = 'code-cmd';
+
+                    // Surround the dollar sign with <span>
+                    val = "<span class='code-dollar'>$</span>" + val.slice(1, val.length).trim();
+                }
+
+                return "<span class='" + cls + "'>" + val + "</span>";
+            });
+
+        $(this).html(lines.join('\n'));
+    });
+
+    return c.html();
+}


### PR DESCRIPTION
Pull request ini menambah filter yang akan memproses mana-mana _code block_ yang mengandungi shell script untuk membezakan di antara garis command dengan garis output. Selain itu, dengan menggunakan CSS, simbol `$` tidak dapat di _select_ bagi memudahkan pembaca untuk _copy-paste_.

Contoh hasil filter:

``````
```sh
$ git init
Initialized empty Git repository in C:/Projects/PROJEK-GIT/.git/
```
``````

<img width="598" alt="screen shot 2015-12-20 at 10 33 50 pm" src="https://cloud.githubusercontent.com/assets/1431045/11918401/9ad2d15e-a76a-11e5-8fd4-e84b90770ca3.png">
